### PR TITLE
phoenix: fix syntax error

### DIFF
--- a/projections/phoenix.projections.json
+++ b/projections/phoenix.projections.json
@@ -1,7 +1,7 @@
 {
   "web/models/*.ex": {
     "type": "model"
-  }
+  },
   "web/controllers/*_controller.ex": {
     "type": "controller"
   },


### PR DESCRIPTION
it wasn't valid json before this.
